### PR TITLE
Set up Phase 0 governance and engineering foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "work"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Format check
+        run: black --check src tests
+      - name: Lint
+        run: ruff check src tests
+      - name: Type check
+        run: mypy src
+      - name: Tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: format lint type test ci
+
+format:
+black src tests
+
+lint:
+ruff check src tests
+
+type:
+mypy src
+
+test:
+pytest
+
+ci: format lint type test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# REFRACTOR Engineering Foundations
+
+This repository hosts the implementation artifacts for the REFRACTOR program. The Phase 0 deliverables
+bootstrap governance, engineering infrastructure, and planning materials so later phases can iterate
+quickly.
+
+## Repository layout
+
+- `docs/` – governance, planning, and operational documentation.
+- `src/` – Python source packages for telemetry and future system components.
+- `tests/` – unit tests executed by the CI pipeline.
+- `tools/` – helper scripts and automation entrypoints.
+- `.github/workflows/` – CI/CD definitions.
+- `specification/` – canonical REFRACTOR requirements and implementation plan (provided).
+
+## Development setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+## Quality checks
+
+| Command       | Description                                     |
+| ------------- | ----------------------------------------------- |
+| `make format` | Format code using Black.                        |
+| `make lint`   | Lint code using Ruff.                           |
+| `make type`   | Run mypy type checks.                           |
+| `make test`   | Execute the pytest unit test suite.             |
+| `make ci`     | Run the full CI sequence (format, lint, type, tests). |
+

--- a/docs/documentation_workspace.md
+++ b/docs/documentation_workspace.md
@@ -1,0 +1,24 @@
+# Documentation Workspace Plan
+
+The REFRACTOR program maintains a centralized workspace that links specification material, design
+decisions, and operational records.
+
+## Structure
+- **Specification Hub:** Direct links to `specification/REFRACTOR_SPEC.md` and the implementation plan.
+- **Phase Journals:** Subdirectories `docs/phases/phase_<n>/` for meeting notes, retrospectives, and sign-offs.
+- **Decision Log:** Append-only register capturing architectural decisions (ADR format) located at
+  `docs/decisions/`.
+- **Knowledge Base:** Glossary and onboarding material for new contributors stored under `docs/glossary/`.
+
+## Access & Permissions
+- Editable by core engineering, safety, and product stakeholders.
+- Read-only mirrors for extended collaborators to maintain alignment without jeopardizing integrity.
+
+## Tooling
+- Workspace synchronized with repository via docs-as-code model; changes flow through pull requests.
+- Weekly documentation audits ensure artifacts reflect current program state.
+
+## Next Steps
+- Populate glossary with terminology from the specification.
+- Stand up ADR template before Phase 1 kickoff.
+- Automate changelog generation using GitHub Actions after CI passes.

--- a/docs/inbox_outbox_policy.md
+++ b/docs/inbox_outbox_policy.md
@@ -1,0 +1,23 @@
+# Inbox/Outbox Workflow Policy
+
+## Purpose
+Ensure program artifacts transition from planned to completed states with clear traceability.
+
+## Workflow
+1. Author creates or updates checklist/task document inside `inbox/`.
+2. Work item owner completes deliverables and gathers supporting evidence (links to docs, tests, metrics).
+3. Owner requests review from accountable lead; reviewers leave approval in document footer.
+4. Upon approval, document is copied to `outbox/` with timestamped filename and changelog entry.
+5. `inbox/` copy replaced with pointer to outbox artifact and status updated to ✅.
+
+## Naming Conventions
+- `inbox/Phase_<n>_<description>.md` for active work.
+- `outbox/<YYYYMMDD>_Phase_<n>_<description>.md` for archived artifacts.
+
+## Tooling
+- Git-based workflow ensures history preservation.
+- Optional automation script (`tools/archive_checklist.py`) will handle copy + metadata in later phase.
+
+## Communication
+- Weekly digest summarizes inbox status and newly archived artifacts.
+- Any blockers flagged in daily standup and tracked until resolved.

--- a/docs/operating_ceremonies.md
+++ b/docs/operating_ceremonies.md
@@ -1,0 +1,28 @@
+# Operating Ceremonies
+
+## Recurring Meetings
+- **Daily Async Standup (All Teams)**
+  - Channel: #refactor-standup
+  - Format: Yesterday, Today, Blockers
+  - Owner: Program Manager
+
+- **Weekly Cross-Team Sync (Mondays 10:00-10:45 PT)**
+  - Agenda: dependency review, checklist progress, risk updates
+  - Attendees: Team leads, Program Manager, Safety representative
+
+- **Steering Committee Review (Wednesdays 14:00-15:00 PT)**
+  - Agenda: milestone tracking, resource allocation, escalation handling
+  - Attendees: Executive sponsors, architecture, infrastructure, retrieval, safety leads, Program Manager
+
+- **Risk Triage Council (As Needed, <24h from escalation)**
+  - Trigger: Any severity ≥ high risk or telemetry anomaly outside SLA guardrails
+  - Outcomes: mitigation owner assignment, follow-up tasks, communication plan
+
+- **Phase Gate Review (End of Each Phase)**
+  - Deliverables: checklist walkthrough, metrics validation, approval sign-off
+  - Artifacts: meeting minutes stored in `docs/reviews/`
+
+## Calendar Management
+- Master calendar maintained in shared workspace with auto-invite distribution.
+- Program Manager ensures invites sent ≥1 week before first occurrence.
+- Time-zone friendly options recorded; asynchronous updates allowed for distributed teams.

--- a/docs/phase1_backlog.md
+++ b/docs/phase1_backlog.md
@@ -1,0 +1,11 @@
+# Phase 1 Backlog Seed
+
+| ID | Title | Description | Owner | Estimate (pts) | Dependencies |
+| -- | ----- | ----------- | ----- | -------------- | ------------ |
+| P1-1 | Reframer schema validator | Implement JSON schema validation pipeline for requests | Reframer Lead | 5 | Phase 0 telemetry | 
+| P1-2 | Role tagging module | Map protocol tags to role embeddings and mask bits | Reframer Lead | 8 | P1-1 |
+| P1-3 | Tokenizer vocabulary bootstrap | Create extensible vocabulary with placeholder merges | Tokenization Lead | 13 | Phase 0 repo scaffolding |
+| P1-4 | Mask compiler rule ingestion | Parse YAML rules and generate mask bitsets | Distinction Engine Lead | 8 | P1-2 |
+| P1-5 | Mask legality property tests | Implement property-based tests for mask conformance | QA Lead | 5 | P1-4 |
+| P1-6 | Telemetry for mask entropy | Emit metrics for mask entropy anomalies | Telemetry Lead | 3 | P1-4 |
+| P1-7 | Distinction engine integration harness | Connect reframer, tokenizer, mask compiler for end-to-end flow | Integration Lead | 8 | P1-1,P1-3,P1-4 |

--- a/docs/program_charter.md
+++ b/docs/program_charter.md
@@ -1,0 +1,45 @@
+# REFRACTOR Program Charter
+
+## Purpose
+REFRACTOR delivers a production-ready sequence architecture that supersedes conventional Transformer
+systems. The program integrates retrieval, mixture-of-experts routing, and persistent memory under
+quantitative safety and telemetry guardrails.
+
+## Scope
+- Implement core model components spanning reframer, distinction engine, relation fabric, transformation
+  core, memory, training, and serving systems.
+- Provide governance, tooling, and operational processes so multidisciplinary teams can deliver features
+  across seven implementation phases.
+
+## Success Metrics
+- ✅ Architecture meets performance targets defined in `specification/REFRACTOR_SPEC.md`.
+- ✅ Telemetry, safety, and retrieval guardrails remain within SLA thresholds during pilot launches.
+- ✅ All program phases exit with approved checklists archived in `outbox/`.
+
+## Governance Structure
+- **Executive Sponsors:** VP Research, VP Product.
+- **Steering Committee:** Architecture lead, Infrastructure lead, Retrieval lead, Safety lead,
+  Program manager.
+- **Decision Forums:**
+  - Weekly steering review for strategic adjustments.
+  - Phase gates aligned to implementation plan milestones.
+  - Risk triage council ad-hoc when severity ≥ high.
+
+## Escalation Paths
+1. Team lead attempts resolution within 1 business day.
+2. Escalate to steering committee for arbitration.
+3. Executive sponsors notified if resolution exceeds 3 business days or scope impacts safety/compliance.
+
+## Communication Plan
+- Daily async standup updates in shared workspace.
+- Weekly synchronous standup across teams.
+- Bi-weekly stakeholder readout summarizing metrics, risks, and next steps.
+
+## Dependencies
+Phase 0 has no external dependencies but seeds infrastructure for all later phases.
+
+## Approvals
+- Engineering Director – _pending_
+- Research Director – _pending_
+- Product Director – _pending_
+- Safety Director – _pending_

--- a/docs/raci_matrix.md
+++ b/docs/raci_matrix.md
@@ -1,0 +1,14 @@
+# REFRACTOR Phase 0 RACI Matrix
+
+| Workstream                                 | Responsible                | Accountable          | Consulted                                      | Informed                               |
+| ------------------------------------------ | -------------------------- | -------------------- | ---------------------------------------------- | -------------------------------------- |
+| Program charter & governance               | Program Manager            | Executive Sponsors   | Architecture, Safety, Product leads            | All engineering teams                  |
+| Repository scaffolding & CI                | Infrastructure Lead        | Architecture Lead    | Tooling, Retrieval teams                       | Entire engineering org                 |
+| Telemetry heartbeat instrumentation        | Infrastructure Lead        | Safety Lead          | Reliability engineering                        | Steering committee                     |
+| Inbox/outbox process definition            | Program Manager            | Program Manager      | Team leads, Legal                              | All contributors                       |
+| Work breakdown structure (WBS)             | Program Manager            | Architecture Lead    | Team leads                                     | Stakeholders                           |
+| Backlog seeding for Phase 1                | Reframer Lead              | Architecture Lead    | Tokenization, Safety teams                     | Program manager, Infrastructure lead   |
+| Risk register                              | Program Manager            | Safety Lead          | All team leads                                 | Steering committee                     |
+| SLA dashboard skeleton                     | Telemetry Lead             | Safety Lead          | Infrastructure, Retrieval teams                | Stakeholders                           |
+| Ceremonies scheduling                      | Program Manager            | Program Manager      | Team leads                                     | All participants                       |
+| Secrets management templates               | DevOps Engineer            | Infrastructure Lead  | Security, Safety teams                          | Engineering teams                      |

--- a/docs/risk_register.md
+++ b/docs/risk_register.md
@@ -1,0 +1,9 @@
+# Risk Register
+
+| ID | Risk Description | Category       | Likelihood | Impact | Mitigation Owner     | Mitigation Plan | Status |
+| -- | ---------------- | -------------- | ---------- | ------ | -------------------- | --------------- | ------ |
+| R1 | Delay in CI infrastructure readiness blocking downstream work | Schedule | Medium | High | Infrastructure Lead | Parallelize CI setup with repo scaffolding; use canned workflows | Open |
+| R2 | Telemetry heartbeat not integrated with monitoring stack | Technical | Low | Medium | Telemetry Lead | Implement local exporter + API mock, validate via unit tests | Open |
+| R3 | Lack of clarity on retrieval vs. safety responsibilities | Organizational | Medium | Medium | Program Manager | Publish RACI matrix and confirm in steering review | Open |
+| R4 | Secrets management misconfiguration leading to credential leaks | Security | Low | High | DevOps Engineer | Adopt template-based configuration with peer review and secret scanning | Open |
+| R5 | Scope creep in Phase 1 backlog | Scope | Medium | Medium | Program Manager | Enforce change control and backlog grooming cadence | Open |

--- a/docs/sla_dashboard_skeleton.md
+++ b/docs/sla_dashboard_skeleton.md
@@ -1,0 +1,14 @@
+# SLA Dashboard Skeleton
+
+| Metric Category | Metric | Target | Placeholder Data Source | Notes |
+| --------------- | ------ | ------ | ----------------------- | ----- |
+| Latency | P95 end-to-end inference latency | ≤ 450 ms | Telemetry heartbeat (synthetic) | Replace with production metrics in Phase 6 |
+| Availability | Request success rate | ≥ 99.5% | Heartbeat success ratio | Define alert at 99.0% |
+| Retrieval Precision | Precision@k for retrieval responses | ≥ 0.85 | Placeholder fixture results | Integrate with retrieval service in Phase 2 |
+| Safety | Tool invocation compliance rate | ≥ 0.98 | Synthetic compliance log | Align with safety enforcement in Phase 6 |
+| Telemetry | Mask entropy within bounds | 0.2 ≤ H ≤ 0.9 | Mask entropy stub | Derived from Distinction Engine metrics |
+
+## Dashboard Hosting Plan
+- Hosted in observability platform with program-level access controls.
+- Metrics updated via CI-driven data pushes until live telemetry is available.
+- Alert routing configured to #refactor-ops channel and on-call rotation.

--- a/docs/telemetry_plan.md
+++ b/docs/telemetry_plan.md
@@ -1,0 +1,21 @@
+# Telemetry Heartbeat Plan
+
+## Objectives
+- Provide early visibility into system health before full observability stack is available.
+- Validate that CI pipelines can execute telemetry-related unit tests.
+
+## Implementation Outline
+1. Implement in-memory heartbeat exporter (`refactor.telemetry.TelemetryExporter`).
+2. Emit heartbeat events from foundational services (to be integrated in later phases).
+3. Forward events to external sinks once infrastructure endpoints are provisioned.
+
+## Metrics Captured
+- Subsystem identifier
+- Status string (`ok`, `degraded`, `error`)
+- Timestamp (Unix epoch seconds)
+- Optional metadata (e.g., endpoint ID, deployment region)
+
+## Verification
+- Unit tests validate emission, querying, and aggregation behavior.
+- CI workflow runs tests on every push and pull request.
+- Placeholder dashboard consumes exported metrics for SLA skeleton.

--- a/docs/work_breakdown_structure.md
+++ b/docs/work_breakdown_structure.md
@@ -1,0 +1,20 @@
+# Phase 0 Work Breakdown Structure
+
+## 0.1 Governance
+- 0.1.1 Draft program charter
+- 0.1.2 Validate RACI matrix with stakeholders
+- 0.1.3 Schedule ceremonies and publish calendar
+- 0.1.4 Stand up documentation workspace
+
+## 0.2 Engineering Foundations
+- 0.2.1 Initialize repository structure and scaffolding
+- 0.2.2 Configure formatting and linting tools
+- 0.2.3 Implement CI workflow covering format, lint, type check, tests
+- 0.2.4 Provision secrets management templates
+- 0.2.5 Build telemetry heartbeat exporter
+
+## 0.3 Planning & Risk Management
+- 0.3.1 Seed Phase 1 backlog tickets
+- 0.3.2 Record risk register and mitigation assignments
+- 0.3.3 Draft SLA dashboard skeleton
+- 0.3.4 Define inbox/outbox policy and communication plan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "refactor"
+version = "0.0.1"
+description = "REFRACTOR engineering foundations package"
+authors = [{name = "REFRACTOR Program", email = "eng@refactor.local"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "black>=24.3.0",
+  "ruff>=0.1.9",
+  "mypy>=1.8.0",
+  "pytest>=7.4.0",
+]
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]
+
+[tool.mypy]
+python_version = "3.11"
+warn_unused_configs = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/refactor/__init__.py
+++ b/src/refactor/__init__.py
@@ -1,0 +1,5 @@
+"""REFRACTOR engineering foundations package."""
+
+from .telemetry.heartbeat import HeartbeatEvent, TelemetryExporter
+
+__all__ = ["HeartbeatEvent", "TelemetryExporter"]

--- a/src/refactor/telemetry/__init__.py
+++ b/src/refactor/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Telemetry utilities for the REFRACTOR program."""
+
+from .heartbeat import HeartbeatEvent, TelemetryExporter
+
+__all__ = ["HeartbeatEvent", "TelemetryExporter"]

--- a/src/refactor/telemetry/heartbeat.py
+++ b/src/refactor/telemetry/heartbeat.py
@@ -1,0 +1,98 @@
+"""Lightweight telemetry heartbeat exporter used during Phase 0.
+
+The exporter provides an in-memory sink that other modules can depend on while CI and
+observability pipelines are being established. It supports thread-safe emission of heartbeat
+events and exposes helpers to query the latest status for a subsystem.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from threading import Lock
+from time import time
+from typing import Callable, Dict, List, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class HeartbeatEvent:
+    """Represents a single heartbeat sample."""
+
+    subsystem: str
+    status: str
+    timestamp: float
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+
+class TelemetryExporter:
+    """Collects and forwards heartbeat events."""
+
+    def __init__(
+        self,
+        sink: Optional[Callable[[HeartbeatEvent], None]] = None,
+        *,
+        clock: Callable[[], float] = time,
+    ) -> None:
+        self._sink = sink
+        self._clock = clock
+        self._events: List[HeartbeatEvent] = []
+        self._lock = Lock()
+
+    def emit_heartbeat(self, subsystem: str, status: str = "ok", **metadata: str) -> HeartbeatEvent:
+        """Record a heartbeat for ``subsystem``.
+
+        Args:
+            subsystem: Name of the emitting subsystem.
+            status: Optional status string, ``"ok"`` by default.
+            **metadata: Additional key/value metadata to associate with the heartbeat.
+
+        Returns:
+            The :class:`HeartbeatEvent` that was emitted.
+        """
+
+        event = HeartbeatEvent(
+            subsystem=subsystem,
+            status=status,
+            timestamp=float(self._clock()),
+            metadata=dict(metadata),
+        )
+
+        with self._lock:
+            self._events.append(event)
+
+        if self._sink is not None:
+            self._sink(event)
+
+        return event
+
+    def latest(self, subsystem: Optional[str] = None) -> Optional[HeartbeatEvent]:
+        """Return the most recent heartbeat.
+
+        Args:
+            subsystem: Optional subsystem filter. If provided, only heartbeats matching the
+                subsystem are considered.
+        """
+
+        with self._lock:
+            if subsystem is None:
+                return self._events[-1] if self._events else None
+
+            for event in reversed(self._events):
+                if event.subsystem == subsystem:
+                    return event
+
+        return None
+
+    def export_snapshot(self) -> List[HeartbeatEvent]:
+        """Return a copy of all recorded heartbeats."""
+
+        with self._lock:
+            return list(self._events)
+
+    def aggregate_status(self) -> Dict[str, str]:
+        """Compute the latest status per subsystem."""
+
+        aggregate: Dict[str, str] = {}
+        with self._lock:
+            for event in self._events:
+                aggregate[event.subsystem] = event.status
+        return aggregate

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from refactor.telemetry import TelemetryExporter
+
+
+def test_emit_heartbeat_records_event() -> None:
+    exporter = TelemetryExporter(clock=lambda: 123.0)
+    event = exporter.emit_heartbeat("retrieval", status="ok", endpoint="primary")
+
+    assert event.subsystem == "retrieval"
+    assert event.status == "ok"
+    assert event.timestamp == 123.0
+    assert event.metadata == {"endpoint": "primary"}
+
+
+def test_latest_filters_by_subsystem() -> None:
+    exporter = TelemetryExporter(clock=lambda: 1.0)
+    exporter.emit_heartbeat("retrieval", status="ok")
+    exporter.emit_heartbeat("safety", status="degraded")
+
+    latest = exporter.latest("retrieval")
+    assert latest is not None
+    assert latest.subsystem == "retrieval"
+    assert exporter.latest("unknown") is None
+
+
+def test_export_snapshot_returns_copy() -> None:
+    exporter = TelemetryExporter(clock=lambda: 1.0)
+    exporter.emit_heartbeat("retrieval")
+    snapshot = exporter.export_snapshot()
+
+    snapshot.clear()
+    assert exporter.export_snapshot()  # original data remains
+
+
+def test_aggregate_status_reflects_latest_per_subsystem() -> None:
+    exporter = TelemetryExporter(clock=lambda: 1.0)
+    exporter.emit_heartbeat("retrieval", status="ok")
+    exporter.emit_heartbeat("retrieval", status="degraded")
+    exporter.emit_heartbeat("safety", status="ok")
+
+    assert exporter.aggregate_status() == {"retrieval": "degraded", "safety": "ok"}

--- a/tools/secrets_template.env
+++ b/tools/secrets_template.env
@@ -1,0 +1,6 @@
+# Environment configuration template
+# Copy to `.env` and fill in values. Do not commit populated secrets.
+REFRACTOR_TELEMETRY_ENDPOINT=https://telemetry.example.com/api
+REFRACTOR_TELEMETRY_TOKEN=
+REFRACTOR_DB_URL=
+REFRACTOR_RETRIEVAL_API_KEY=


### PR DESCRIPTION
## Summary
- document program governance, operating ceremonies, risk management, and backlog seeds for Phase 0
- scaffold the repository with Python project metadata, tooling helpers, and CI workflow coverage
- add a telemetry heartbeat exporter with accompanying unit tests and secrets template for future integration

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d13e991e88833099698c43fa465d88